### PR TITLE
templated run with num workers enabled. doesn't work otherwise

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
@@ -171,6 +171,12 @@ public class WordCount {
     @Required
     String getOutput();
     void setOutput(String value);
+
+    @Description("The ammount of workers for the job. Defaults to 1")
+    @Default.Integer(1)
+    int getWorkerCount();
+
+    void setWorkerCount(int count);
   }
 
   public static void main(String[] args) {
@@ -179,6 +185,7 @@ public class WordCount {
     options.setStagingLocation("gs://test_bucket/staging");
     options.setRunner(DataflowRunner.class);
     options.setTemplateLocation("gs://test_bucket/staging/templates/WordCountTemplate");
+    options.setNumWorkers(options.getWorkerCount());
 
     // Concepts #2 and #3: Our pipeline applies the composite CountWords transform, and passes the
     // static FormatAsTextFn() to the ParDo transform.


### PR DESCRIPTION
This is the error we get when trying to use numWorkers directly:

![screen shot 2017-08-01 at 3 00 33 pm](https://user-images.githubusercontent.com/148319/28849204-e3dd3336-76ca-11e7-843d-b64163af2030.png)

In text: ` The workflow could not be created. Causes: (e38248db85d4c1ee): Found unexpected parameters: ['numWorkers' (perhaps you meant 'network')]`
